### PR TITLE
Fix status label colors on "My Events" shortcode output

### DIFF
--- a/assets/css/ees-espresso-my-events.css
+++ b/assets/css/ees-espresso-my-events.css
@@ -35,7 +35,6 @@
     cursor: pointer;
 }
 
-
 .espresso-my-events .ee-my-events-two-thirds {
     width: 63%;
     margin-left: 20px;
@@ -76,13 +75,14 @@
 .espresso-my-events-table tr td.reg-status-RPP, .espresso-my-events-table tr td.event-status-DTU {
     color: #00B1CA;
 }
+
 .ee-status-RPP, .ee-status-DTU {
     background-color: #00B1CA;
 }
 
 /*cancelled registration, expired event*/
 .espresso-my-events-table tr td.reg-status-RCN, .espresso-my-events-table tr td.event-status-DTE {
-    color : #AC9D9C;
+    color: #AC9D9C;
 }
 
 .ee-status-RCN, .ee-status-DTE {
@@ -91,7 +91,7 @@
 
 /*declined registration, cancelled event*/
 .espresso-my-events-table tr td.reg-status-RDC, .espresso-my-events-table tr td.event-status-DTC {
-    color : #E44064;
+    color: #E44064;
 }
 
 .ee-status-RDC, .ee-status-DTC {
@@ -100,7 +100,7 @@
 
 /*approved registration, active event*/
 .espresso-my-events-table tr td.reg-status-RAP, .espresso-my-events-table tr td.event-status-DTA {
-    color : #70CC50;
+    color: #70CC50;
 }
 
 .ee-status-RAP, .ee-status-DTA {
@@ -118,7 +118,7 @@
 
 /*waitlist registration, postponed event*/
 .espresso-my-events-table tr td.reg-status-RWL, .espresso-my-events-table tr td.event-status-DTP {
-    color : #8A549A;
+    color: #8A549A;
 }
 
 .ee-status-RWL, .ee-status-DTP {
@@ -128,7 +128,7 @@
 
 /*inactive event*/
 .espresso-my-events-table tr td.event-status-DTI {
-    color : #403A3A;
+    color: #403A3A;
 }
 
 .ee-status-DTI {
@@ -147,36 +147,37 @@
 /* legend container  - taken from ee-admin-page.css */
 /** LIST-TABLE-LEGEND **/
 .espresso-my-events-legend-list {
-    margin-top   : 0;
-    padding      : 5px;
-    margin-right : 20px;
+    margin-top: 0;
+    padding: 5px;
+    margin-right: 20px;
     float: left;
 }
 
 .espresso-my-events-legend-list dt {
-    line-height : 25px;
+    line-height: 25px;
     font-weight: normal;
 }
 
 .ee-status-legend {
-    display        : inline-block;
-    width          : 18px;
-    height         : 18px;
-    vertical-align : middle;
+    display: inline-block;
+    width: 18px;
+    height: 18px;
+    vertical-align: middle;
 }
 
 .espresso-my-events-legend-container .dashicons,
 .espresso-my-events-legend-container .ee-icon {
-    font-size : 18px;
+    font-size: 18px;
     vertical-align: middle;
 }
+
 .espresso-my-events-legend-container .ee-icon-size-8 {
     vertical-align: top;
     margin-bottom: .5em;
 }
 
 .ee-legend-description {
-    margin-left : 10px;
+    margin-left: 10px;
 }
 
 .ee-status-legend-box {

--- a/assets/css/ees-espresso-my-events.css
+++ b/assets/css/ees-espresso-my-events.css
@@ -109,7 +109,7 @@
 
 /*not-approved registration*/
 .espresso-my-events-table tr td.reg-status-RNA {
-    border-left-color : #E76700;
+    color: #E76700;
 }
 
 .ee-status-RNA {
@@ -137,7 +137,7 @@
 
 /*incomplete registration, sold out event*/
 .espresso-my-events-table tr td.reg-status-RIC, .espresso-my-events-table tr td.event-status-DTS {
-    border-left-color : #FCB93C;
+    color: #FCB93C;
 }
 
 .ee-status-RIC, .ee-status-DTS {


### PR DESCRIPTION
<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Some registration statuses do not get the color applied to their status bar. 
## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
This was tested by changing to reg. statuses for some registrations, then checking the page with the [ESPRESSO_MY_EVENTS] shortcode to make sure the colors were correct.
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

