### PR TITLE
Use PHP function is_readable instead of method from EE filesystem class

### DIFF
--- a/domain/entities/shortcodes/EspressoMyEvents.php
+++ b/domain/entities/shortcodes/EspressoMyEvents.php
@@ -204,7 +204,7 @@ class EspressoMyEvents extends EspressoShortcode
             $attributes['template'] = $this->request->get('template');
         }
         // template tags file is not loaded apparently so need to load:
-        if (EEH_File::is_readable(EE_PUBLIC . 'template_tags.php')) {
+        if (is_readable(EE_PUBLIC . 'template_tags.php')) {
             require_once EE_PUBLIC . 'template_tags.php';
         }
 
@@ -364,7 +364,7 @@ class EspressoMyEvents extends EspressoShortcode
             $accepted_object_types = array('Event', 'Registration');
             if (isset($template_object_map[ $template_slug ]['object_type'], $template_object_map[ $template_slug ]['path'])
                 && in_array($template_object_map[ $template_slug ]['object_type'], $accepted_object_types, true)
-                && EEH_File::is_readable(
+                && is_readable(
                     EE_WPUSERS_TEMPLATE_PATH . $template_object_map[ $template_slug ]['path']
                 )
             ) {


### PR DESCRIPTION
From the comment block in EEH_File:

> if FS_METHOD is defined to be ssh or ftp, and the ftp password isn't entered into wp-config.php, EEH_File::is_readable() will THROW AN EXCEPTION when trying to read anything. 

(all caps theirs)

<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
This avoids throwing an exception along with a fatal error on the front end of someone's site when they try to use the [ESPRESSO_MY_EVENTS] shortcode where the filesystem is set up a bit differently than normal.

Examples from support topics where this has happened:
https://eventespresso.com/topic/my-events-page-breaking/#post-281329
https://eventespresso.com/topic/shortcode-fatal-error/
https://eventespresso.com/topic/wp-user-integration-error-when-viewing-registration-page/
https://eventespresso.com/topic/espresso_my_events-not-working-with-theme-my-login-tml-plugin/
https://eventespresso.com/topic/blank-page-for-espresso_my_events-shortcode/

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Verified that the [ESPRESSO_MY_EVENTS] shortcode still parses as expected.
## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
