### PR TITLE
Fix getTemplateInfo to allow for custom templates

### DIFF
--- a/domain/entities/shortcodes/EspressoMyEvents.php
+++ b/domain/entities/shortcodes/EspressoMyEvents.php
@@ -364,9 +364,6 @@ class EspressoMyEvents extends EspressoShortcode
             $accepted_object_types = array('Event', 'Registration');
             if (isset($template_object_map[ $template_slug ]['object_type'], $template_object_map[ $template_slug ]['path'])
                 && in_array($template_object_map[ $template_slug ]['object_type'], $accepted_object_types, true)
-                && is_readable(
-                    EE_WPUSERS_TEMPLATE_PATH . $template_object_map[ $template_slug ]['path']
-                )
             ) {
                 // yay made it here you awesome template object you.
                 return $template_info;

--- a/domain/entities/shortcodes/EspressoMyEvents.php
+++ b/domain/entities/shortcodes/EspressoMyEvents.php
@@ -372,7 +372,7 @@ class EspressoMyEvents extends EspressoShortcode
         // oh noes, not setup properly, so let's just use a safe known default.
         return array(
             'template'    => 'event_section',
-            'object_type' => 'Registration',
+            'object_type' => 'Event',
             'path'        => 'loop-espresso_my_events-event_section.template.php',
         );
     }


### PR DESCRIPTION
## Problem this Pull Request solves
Currently, you can't load custom versions of the `loop-` template files for the My Events section.

You can override the defaults, but if you use something like:

`[ESPRESSO_MY_EVENTS template=example_event_section]`

To load a custom template from your theme it will fail and revert back to a default (which is also broken).

Note I've intentionally not fixed the older class but if you prefer that is updated I can.

## How has this been tested
First, with MASTER, load the My events section on the front end with the normal shortcode with no template attribute, you should have some output on the table.

Now use the above shortcode, you'll see 'You have no events yet', that's there's no object mapping for that template so uses defaults (which are broken).

Add this snippet to your site:

```
add_filter('FHEE__EES_Espresso_My_Events__process_shortcode_template_object_map','tw_custom_my_events_template_map', 10);
function tw_custom_my_events_template_map($object_map) {
	$object_map['example_event_section'] = array(
		'object_type' => 'Event',
		'path' => 'loop-espresso_my_events-example_event_section.template.php'
	);
	return $object_map;
}
```

That tells EE to map `template=example_event_section` to a `loop-espresso_my_events-example_event_section.template.php` template file and also maps the objects it expects Events.

Copy the default 'loop-espresso_my_events-event_section.template.php' from the add-on itself and place it in your themes root directory (Make a change to the template so you know it loads, line 37 just before the closing H3 add some text or whatever you prefer), then rename it to 'loop-espresso_my_events-example_event_section.template.php'.

Reload the page, note that you still get the same error showing no events, even though we've set up object mapping for that template. That's because the template doesn't exist within the plugins own directory, so again it reverts to defaults.

Switch to this branch, you're custom template should load.

Remove the snippet provided above and reload the page (leave the shortcode as is), you should now revert to the default event_section template and it should have events listed again.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
