### PR TITLE
Filter the $query_args used to pull the objects.

### DIFF
--- a/domain/entities/shortcodes/EspressoMyEvents.php
+++ b/domain/entities/shortcodes/EspressoMyEvents.php
@@ -451,6 +451,13 @@ class EspressoMyEvents extends EspressoShortcode
             return $object_info;
         }
 
+        // allow $query_args to be filtered.
+        $query_args = apply_filters(
+            'FHEE__Espresso_My_Events__getTemplateObjects__query_args', 
+            $query_args, 
+            $template_arguments, 
+            $attendee_id
+        );
         $object_info['objects'] = $model->get_all($query_args);
         $object_info['object_count'] = $model->count(array($query_args[0]), null, true);
         return $object_info;

--- a/domain/entities/shortcodes/EspressoMyEvents.php
+++ b/domain/entities/shortcodes/EspressoMyEvents.php
@@ -453,9 +453,9 @@ class EspressoMyEvents extends EspressoShortcode
 
         // allow $query_args to be filtered.
         $query_args = apply_filters(
-            'FHEE__Espresso_My_Events__getTemplateObjects__query_args', 
-            $query_args, 
-            $template_arguments, 
+            'FHEE__Espresso_My_Events__getTemplateObjects__query_args',
+            $query_args,
+            $template_arguments,
             $attendee_id
         );
         $object_info['objects'] = $model->get_all($query_args);

--- a/domain/entities/shortcodes/EspressoMyEvents.php
+++ b/domain/entities/shortcodes/EspressoMyEvents.php
@@ -452,7 +452,7 @@ class EspressoMyEvents extends EspressoShortcode
         }
 
         // allow $query_args to be filtered.
-        $query_args = apply_filters(
+        $query_args = (array) apply_filters(
             'FHEE__Espresso_My_Events__getTemplateObjects__query_args',
             $query_args,
             $template_arguments,


### PR DESCRIPTION
See: https://eventespresso.com/topic/per_page-parameter-not-working-in-my-events/#post-292493

We've had a lot of fair few requests to filter out events based on status, mainly filtering expired events from view like above, so adding this filter is an easy win that works better than filtering {objects} after the query.

## How has this been tested
Add this snippet to your site:

```
add_filter(
	'FHEE__Espresso_My_Events__getTemplateObjects__query_args',
	'tw_ee_filter_getTemplateObjects__query_args',
	10,
	3
);
function tw_ee_filter_getTemplateObjects__query_args( $query_args, $template_args, $att_id) {
	if ($template_args['object_type'] === 'Event') {
		$query_args[0]['Datetime.DTT_EVT_end'] = array( '>=', EEM_Datetime::instance()->current_time_for_query('DTT_EVT_end'));	
	}
	if ($template_args['object_type'] === 'Registration') {
		$query_args[0]['Event.Datetime.DTT_EVT_end'] = array( '>=', EEM_Datetime::instance()->current_time_for_query('DTT_EVT_end'));	
	}
	//d($query_args);
	return $query_args;
}
```

Load up `[ESPRESSO_MY_EVENTS]` and confirm your events still load.

add `per_page=X` (I used per_age=2) and confirm that only active/upcoming events are shown in the list (use Datetime.DTT_EVT_start) for upcoming events only) and that paging works.

-- Edit --
Updated the above snippet to also work with the `simple_list_table` template, so retest with:

`[ESPRESSO_MY_EVENTS template=simple_list_table]`

And again confirm that paging works as expected.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
