### PR TITLE
Fix resend registration message link not working on paged results (fixes #17)

### DIFF
--- a/EES_Espresso_My_Events.shortcode.php
+++ b/EES_Espresso_My_Events.shortcode.php
@@ -280,7 +280,6 @@ class EES_Espresso_My_Events extends EES_Shortcode
             'template' => isset($attributes['template']) ? $attributes['template'] : 'event_section',
             'per_page' => isset($attributes['per_page']) ? $attributes['per_page'] : 10,
         );
-
         wp_localize_script('ees-my-events-js', 'EE_MYE_JS', $js_object);
     }
 

--- a/assets/js/ees-espresso-my-events.js
+++ b/assets/js/ees-espresso-my-events.js
@@ -16,10 +16,11 @@ jQuery(document).ready( function($) {
         },
 
 
-        doPagination: function( page, per_page, template ) {
+        doPagination: function( page, per_page, template, link ) {
             this.data.ee_mye_page = typeof page === 'undefined' ? 1 : page;
             this.data.per_page = typeof per_page === 'undefined' ? null : per_page;
             this.data.template = typeof template === 'undefined' ? 'event_section' : template;
+            this.data.link = typeof link === 'undefined' ? null : link;
             this.data.successCallback = 'replaceTable';
             this.data.action = 'ee_my_events_load_paged_template';
             this.doAjax();
@@ -33,7 +34,6 @@ jQuery(document).ready( function($) {
                 return false;
             }
             $('.espresso-my-events-inner-content').html(response.content);
-            return;
         },
 
 
@@ -74,7 +74,7 @@ jQuery(document).ready( function($) {
         e.stopPropagation();
         //grab the page being navigated to from the clicked link
         var pageBrowsedTo = parseInt( this.search.replace('?ee_mye_page=','') );
-        EEMYEVENTS.doPagination( pageBrowsedTo, EE_MYE_JS.per_page, EE_MYE_JS.template );
+        EEMYEVENTS.doPagination( pageBrowsedTo, EE_MYE_JS.per_page, EE_MYE_JS.template, EE_MYE_JS.link );
     });
 
 

--- a/assets/js/ees-espresso-my-events.js
+++ b/assets/js/ees-espresso-my-events.js
@@ -16,11 +16,10 @@ jQuery(document).ready( function($) {
         },
 
 
-        doPagination: function( page, per_page, template, link ) {
+        doPagination: function( page, per_page, template ) {
             this.data.ee_mye_page = typeof page === 'undefined' ? 1 : page;
             this.data.per_page = typeof per_page === 'undefined' ? null : per_page;
             this.data.template = typeof template === 'undefined' ? 'event_section' : template;
-            this.data.link = typeof link === 'undefined' ? null : link;
             this.data.successCallback = 'replaceTable';
             this.data.action = 'ee_my_events_load_paged_template';
             this.doAjax();
@@ -74,7 +73,7 @@ jQuery(document).ready( function($) {
         e.stopPropagation();
         //grab the page being navigated to from the clicked link
         var pageBrowsedTo = parseInt( this.search.replace('?ee_mye_page=','') );
-        EEMYEVENTS.doPagination( pageBrowsedTo, EE_MYE_JS.per_page, EE_MYE_JS.template, EE_MYE_JS.link );
+        EEMYEVENTS.doPagination( pageBrowsedTo, EE_MYE_JS.per_page, EE_MYE_JS.template );
     });
 
 

--- a/domain/entities/shortcodes/EspressoMyEvents.php
+++ b/domain/entities/shortcodes/EspressoMyEvents.php
@@ -456,7 +456,7 @@ class EspressoMyEvents extends EspressoShortcode
             $query_args,
             $template_arguments,
             $attendee_id
-        );  
+        );
         $object_info['objects'] = $model->get_all($query_args);
         $object_info['object_count'] = $model->count(array($query_args[0]), null, true);
         return $object_info;

--- a/domain/entities/shortcodes/EspressoMyEvents.php
+++ b/domain/entities/shortcodes/EspressoMyEvents.php
@@ -1,6 +1,7 @@
 <?php
 namespace EventEspresso\WpUser\domain\entities\shortcodes;
 
+use EE_Registry;
 use EventEspresso\core\services\shortcodes\EspressoShortcode;
 use EventEspresso\core\services\cache\PostRelatedCacheManager;
 use EE_Request;
@@ -157,8 +158,8 @@ class EspressoMyEvents extends EspressoShortcode
         $js_object = array(
             'template' => isset($attributes['template']) ? $attributes['template'] : 'event_section',
             'per_page' => isset($attributes['per_page']) ? $attributes['per_page'] : 10,
+            'link' => get_permalink(),
         );
-
         wp_localize_script('ees-my-events-js', 'EE_MYE_JS', $js_object);
     }
 
@@ -293,6 +294,7 @@ class EspressoMyEvents extends EspressoShortcode
         // any parameters coming from the request?
         $per_page = (int) $this->request->get('per_page', $attributes['per_page']);
         $page = (int) $this->request->get(self::MY_EVENTS_PAGE_QUERY_ARGUMENT_KEY, 0);
+        $link = $this->request->get('link', get_permalink());
 
         // if $page is empty then it's likely this is being loaded outside of ajax and wp has usurped
         // the page value for its query.  So let's see if its in the query.
@@ -319,6 +321,7 @@ class EspressoMyEvents extends EspressoShortcode
             'per_page'           => $per_page,
             'path_to_template'   => $template_info['path'],
             'page'               => $page,
+            'link'               => $link,
             'object_count'       => 0,
             'att_id'             => 0,
             'with_wrapper'       => $attributes['with_wrapper'],
@@ -450,7 +453,6 @@ class EspressoMyEvents extends EspressoShortcode
             // get out no valid object_types here.
             return $object_info;
         }
-
         $object_info['objects'] = $model->get_all($query_args);
         $object_info['object_count'] = $model->count(array($query_args[0]), null, true);
         return $object_info;

--- a/domain/entities/shortcodes/EspressoMyEvents.php
+++ b/domain/entities/shortcodes/EspressoMyEvents.php
@@ -158,7 +158,6 @@ class EspressoMyEvents extends EspressoShortcode
         $js_object = array(
             'template' => isset($attributes['template']) ? $attributes['template'] : 'event_section',
             'per_page' => isset($attributes['per_page']) ? $attributes['per_page'] : 10,
-            'link' => get_permalink(),
         );
         wp_localize_script('ees-my-events-js', 'EE_MYE_JS', $js_object);
     }
@@ -294,7 +293,6 @@ class EspressoMyEvents extends EspressoShortcode
         // any parameters coming from the request?
         $per_page = (int) $this->request->get('per_page', $attributes['per_page']);
         $page = (int) $this->request->get(self::MY_EVENTS_PAGE_QUERY_ARGUMENT_KEY, 0);
-        $link = $this->request->get('link', get_permalink());
 
         // if $page is empty then it's likely this is being loaded outside of ajax and wp has usurped
         // the page value for its query.  So let's see if its in the query.
@@ -321,7 +319,6 @@ class EspressoMyEvents extends EspressoShortcode
             'per_page'           => $per_page,
             'path_to_template'   => $template_info['path'],
             'page'               => $page,
-            'link'               => $link,
             'object_count'       => 0,
             'att_id'             => 0,
             'with_wrapper'       => $attributes['with_wrapper'],

--- a/templates/content-espresso_my_events-event_section_tickets.template.php
+++ b/templates/content-espresso_my_events-event_section_tickets.template.php
@@ -33,7 +33,7 @@ $ticket = $registration->ticket();
         // resend confirmation email.
         $resend_registration_link = add_query_arg(
             array('token' => $registration->reg_url_link(), 'resend' => true),
-            $link
+            null
         );
         if ($registration->is_primary_registrant() ||
             (! $registration->is_primary_registrant()

--- a/templates/content-espresso_my_events-event_section_tickets.template.php
+++ b/templates/content-espresso_my_events-event_section_tickets.template.php
@@ -33,7 +33,7 @@ $ticket = $registration->ticket();
         // resend confirmation email.
         $resend_registration_link = add_query_arg(
             array('token' => $registration->reg_url_link(), 'resend' => true),
-            get_permalink(EE_Registry::instance()->REQ->get_post_id_from_request())
+            $link
         );
         if ($registration->is_primary_registrant() ||
             (! $registration->is_primary_registrant()

--- a/templates/content-espresso_my_events-simple_list_table.template.php
+++ b/templates/content-espresso_my_events-simple_list_table.template.php
@@ -47,7 +47,7 @@
         // resend confirmation email.
         $resend_registration_link = add_query_arg(
             array( 'token' => $registration->reg_url_link(), 'resend' => true ),
-            get_permalink(EE_Registry::instance()->REQ->get_post_id_from_request())
+            null
         );
         if ($registration->is_primary_registrant() ||
              ( ! $registration->is_primary_registrant()


### PR DESCRIPTION
## Problem this Pull Request solves

This fixes the issue reported in #17.  However it's still less than an _ideal_ fix:

- clicking the resend link does resend the registration but the page is reloaded after and the results will be on the first page.
- I don't think this will work well if the shortcode is used in a widget.

However in order to resolve the above issues:

- We will need the js to receive routing information from the url so redirect urls can go to a specific loaded page in the my events shortcode output.
- A more resilient option other than `get_permalink()` will be needed to get the current page loaded (not just the url for the current `$post` global state).   Doing this will also complicate the "return" after resending because there may be more than one "my events" output in the view depending on how things are setup.

Ideally, it'd be good to refactor this view as a react app and have all all actions done via http request (REST api or admin-ajax) unless there is a link to another page.  That would neatly solve all of the above issues.

**For now**, in the interest of getting a workable solution out for the _majority_ of use-cases, I suggest we roll with the current fix.

## How has this been tested

* [x] Use the `[ESPRESSO_MY_EVENTS]` shortcode on a page.
* [x] View that page while logged in as a user that has registrations to multiple events where the number of events is greater than the per_page limit set via the shortcode.
* [x] Verify that the reported issue is fixed.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
