### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,9 @@
 {
 	"name": "eventespresso/eea-wpuser-integration",
 	"type": "wordpress-plugin",
+	"extra": {
+        "installer-name": "eea-wp-user-integration"
+    },
 	"license": "GPL-2.0-or-later",
 	"description": "An add-on for Event Espresso 4!",
 	"authors" : [


### PR DESCRIPTION
### Fixed wrong installer path via installer name key
We are developing a new website for a client which uses this plugin. As we use composer to manage all WordPress plugins we saw that the installer name seems to be incorrect as it uses "eea-wpuser-registeration" from the package. name but in the code of the plugin there are references to a folder name "eea-wp-user-registration". 

There is an option to set a custom installer name via the composer.json file (https://composer.github.io/installers/#custom-install-names) so that the correct directory folder name is used.

Therefor I've created this fix and hope you will approve this for future composer installations for other developers. Don't hesitate to reach out if you have any question about the pull request.

<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->

## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
