### PR TITLE
Add WP User DOM Data for EDTR

### DIFF
--- a/EE_WPUsers.class.php
+++ b/EE_WPUsers.class.php
@@ -74,7 +74,7 @@ class EE_WPUsers extends EE_Addon
     {
         $this->register_dependencies();
         add_action(
-            'AHEE__EventEspresso_core_services_routing_Router__brewEspresso',
+            'AHEE__EventEspresso_core_services_routing_Router__coreLoadedAndReady',
             [$this, 'handleWpUserRoutes'],
             10,
             3

--- a/domain/entities/routing/EspressoEventEditor.php
+++ b/domain/entities/routing/EspressoEventEditor.php
@@ -16,6 +16,23 @@ use EventEspresso\WpUser\domain\services\assets\EventEditorAssetManager;
  */
 class EspressoEventEditor extends CoreEventEditor
 {
+    /**
+     * @var WpUserData $data_node
+     */
+    protected $data_node;
+
+
+    /**
+     * called just before matchesCurrentRequest()
+     * and allows Route to perform any setup required such as calling setSpecification()
+     *
+     * @return void
+     */
+    public function initialize()
+    {
+        $this->initializeBaristaForDomain(Domain::class);
+    }
+
 
     protected function registerDependencies()
     {
@@ -27,6 +44,22 @@ class EspressoEventEditor extends CoreEventEditor
                 'EventEspresso\core\services\assets\Registry'        => EE_Dependency_Map::load_from_cache,
             ]
         );
+        $this->dependency_map->registerDependencies(
+            WpUserData::class,
+            [
+                'EventEspresso\core\services\json\JsonDataNodeValidator' => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\domain\services\graphql\Utilities'   => EE_Dependency_Map::load_from_cache,
+            ]
+        );
+    }
+
+
+    /**
+     * @return string
+     */
+    protected function dataNodeClass(): string
+    {
+        return WpUserData::class;
     }
 
 
@@ -35,15 +68,14 @@ class EspressoEventEditor extends CoreEventEditor
      *
      * @return bool
      */
-    protected function requestHandler()
+    protected function requestHandler(): bool
     {
-        $this->initializeBaristaForDomain(Domain::class);
         /** @var EventEditorAssetManager $asset_manager */
         $asset_manager = $this->loader->getShared(
             EventEditorAssetManager::class,
             [getWpUserDomain()]
         );
-        add_action('admin_enqueue_scripts', [$asset_manager, 'enqueueEventEditor'], 3);
+        add_action('admin_enqueue_scripts', [$asset_manager, 'enqueueEventEditor']);
         return true;
     }
 }

--- a/domain/entities/routing/GQLRequests.php
+++ b/domain/entities/routing/GQLRequests.php
@@ -25,7 +25,7 @@ class GQLRequests extends CoreGQLRequests
      *
      * @return bool
      */
-    protected function requestHandler()
+    protected function requestHandler(): bool
     {
         /** @var RegisterSchema $schema */
         $schema = $this->loader->getShared(RegisterSchema::class);

--- a/domain/entities/routing/WpUserData.php
+++ b/domain/entities/routing/WpUserData.php
@@ -48,7 +48,6 @@ class WpUserData extends JsonDataNode
             'FHEE__EventEspresso_core_domain_entities_routing_data_nodes_domains_EventEditor__initialize__related_data',
             [$this, 'getTicketCapabilitiesRequired']
         );
-
     }
 
 
@@ -78,18 +77,18 @@ class WpUserData extends JsonDataNode
     {
         $capability_options = [
             'Standard' => [
-                'none' => 'none',
-                'read' => 'Read Capabilities',
+                'none' => esc_html__('none', 'event_espresso'),
+                'read' => esc_html__('Read Capabilities', 'event_espresso'),
             ],
         ];
 
         if (defined('WS_PLUGIN__S2MEMBER_MIN_WP_VERSION')) {
             $capability_options['s2Member'] = [
-                'access_s2member_level0' => 'Level 0 Member',
-                'access_s2member_level1' => 'Level 1 Member',
-                'access_s2member_level2' => 'Level 2 Member',
-                'access_s2member_level3' => 'Level 3 Member',
-                'access_s2member_level4' => 'Level 4 Member',
+                'access_s2member_level0' => esc_html__('Level 0 Member', 'event_espresso'),
+                'access_s2member_level1' => esc_html__('Level 1 Member', 'event_espresso'),
+                'access_s2member_level2' => esc_html__('Level 2 Member', 'event_espresso'),
+                'access_s2member_level3' => esc_html__('Level 3 Member', 'event_espresso'),
+                'access_s2member_level4' => esc_html__('Level 4 Member', 'event_espresso'),
             ];
         }
 

--- a/domain/entities/routing/WpUserData.php
+++ b/domain/entities/routing/WpUserData.php
@@ -76,7 +76,7 @@ class WpUserData extends JsonDataNode
     private function addCapabilityOptions()
     {
         $capability_options = [
-            'Standard' => [
+            esc_html__('Standard', 'event_espresso') => [
                 'none' => esc_html__('none', 'event_espresso'),
                 'read' => esc_html__('Read Capabilities', 'event_espresso'),
             ],

--- a/domain/entities/routing/WpUserData.php
+++ b/domain/entities/routing/WpUserData.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace EventEspresso\WpUser\domain\entities\routing;
+
+use EE_Error;
+use EE_Extra_Meta;
+use EEM_Extra_Meta;
+use EventEspresso\core\domain\services\graphql\Utilities;
+use EventEspresso\core\services\json\JsonDataNode;
+use EventEspresso\core\services\json\JsonDataNodeValidator;
+
+/**
+ * Class WpUserData
+ * injects data into the EventEditor DOM data
+ *
+ * @author  Brent Christensen
+ * @package EventEspresso\WpUser\domain\entities\routing
+ * @since   $VID:$
+ */
+class WpUserData extends JsonDataNode
+{
+
+    const NODE_NAME = 'wpUserData';
+
+    /**
+     * @var array
+     */
+    private $ticket_meta_data = [];
+
+    /**
+     * @var Utilities
+     */
+    private $utilities;
+
+
+    /**
+     * WpUserData JsonDataNode constructor.
+     *
+     * @param JsonDataNodeValidator $validator
+     * @param Utilities             $utilities
+     */
+    public function __construct(JsonDataNodeValidator $validator, Utilities $utilities)
+    {
+        parent::__construct($validator);
+        $this->utilities = $utilities;
+        $this->setNodeName(WpUserData::NODE_NAME);
+        add_filter(
+            'FHEE__EventEspresso_core_domain_entities_routing_data_nodes_domains_EventEditor__initialize__related_data',
+            [$this, 'getTicketCapabilitiesRequired']
+        );
+
+    }
+
+
+    /**
+     * @param array $ticket_meta_data
+     */
+    public function setTicketMetaData(array $ticket_meta_data): void
+    {
+        $this->ticket_meta_data = $ticket_meta_data;
+    }
+
+
+    /**
+     * @return void
+     */
+    public function initialize()
+    {
+        $this->addCapabilityOptions();
+        $this->addTicketMetaData();
+    }
+
+
+    /**
+     * @return void
+     */
+    private function addCapabilityOptions()
+    {
+        $capability_options = [
+            'Standard' => [
+                'none' => 'none',
+                'read' => 'Read Capabilities',
+            ],
+        ];
+
+        if (defined('WS_PLUGIN__S2MEMBER_MIN_WP_VERSION')) {
+            $capability_options['s2Member'] = [
+                'access_s2member_level0' => 'Level 0 Member',
+                'access_s2member_level1' => 'Level 1 Member',
+                'access_s2member_level2' => 'Level 2 Member',
+                'access_s2member_level3' => 'Level 3 Member',
+                'access_s2member_level4' => 'Level 4 Member',
+            ];
+        }
+
+        $this->addData(
+            'capabilityOptions',
+            apply_filters(
+                'FHEE__EventEspresso_WpUser_domain_entities_routing_WpUserData__initialize__capabilityOptions',
+                $capability_options
+            )
+        );
+    }
+
+
+    /**
+     * @return void
+     */
+    private function addTicketMetaData()
+    {
+        $this->addData(
+            'ticketsMeta',
+            apply_filters(
+                'FHEE__EventEspresso_WpUser_domain_entities_routing_WpUserData__initialize__capabilityOptions',
+                $this->ticket_meta_data
+            )
+        );
+    }
+
+
+    /**
+     * @param array $event_editor_gql_data
+     * @return array
+     * @throws EE_Error
+     */
+    public function getTicketCapabilitiesRequired(array $event_editor_gql_data): array
+    {
+        if (isset($event_editor_gql_data['tickets']['nodes'])) {
+            $ticket_meta_data = [];
+            foreach ($event_editor_gql_data['tickets']['nodes'] as $key => $ticket_node) {
+                $extra_meta = isset($ticket_node['dbId'])
+                    ? EEM_Extra_Meta::instance()->get_one(
+                        [
+                            [
+                                'OBJ_ID'   => $ticket_node['dbId'],
+                                'EXM_type' => 'Ticket',
+                                'EXM_key'  => 'ee_ticket_cap_required',
+                            ],
+                        ]
+                    )
+                    : null;
+                if ($extra_meta instanceof EE_Extra_Meta) {
+                    $capabilityRequired                                                      = $extra_meta->value();
+                    $event_editor_gql_data['tickets']['nodes'][ $key ]['capabilityRequired'] = $capabilityRequired;
+                    $ticket_meta_data[ $ticket_node['id'] ]                                  =
+                        ['capabilityRequired' => $capabilityRequired];
+                }
+            }
+            $this->setTicketMetaData($ticket_meta_data);
+        }
+        return $event_editor_gql_data;
+    }
+}

--- a/domain/entities/routing/WpUserData.php
+++ b/domain/entities/routing/WpUserData.php
@@ -76,19 +76,19 @@ class WpUserData extends JsonDataNode
     private function addCapabilityOptions()
     {
         $capability_options = [
-            esc_html__('Standard', 'event_espresso') => [
-                'none' => esc_html__('none', 'event_espresso'),
-                'read' => esc_html__('Read Capabilities', 'event_espresso'),
+            __('Standard', 'event_espresso') => [
+                'none' => __('none', 'event_espresso'),
+                'read' => __('Read Capabilities', 'event_espresso'),
             ],
         ];
 
         if (defined('WS_PLUGIN__S2MEMBER_MIN_WP_VERSION')) {
             $capability_options['s2Member'] = [
-                'access_s2member_level0' => esc_html__('Level 0 Member', 'event_espresso'),
-                'access_s2member_level1' => esc_html__('Level 1 Member', 'event_espresso'),
-                'access_s2member_level2' => esc_html__('Level 2 Member', 'event_espresso'),
-                'access_s2member_level3' => esc_html__('Level 3 Member', 'event_espresso'),
-                'access_s2member_level4' => esc_html__('Level 4 Member', 'event_espresso'),
+                'access_s2member_level0' => __('Level 0 Member', 'event_espresso'),
+                'access_s2member_level1' => __('Level 1 Member', 'event_espresso'),
+                'access_s2member_level2' => __('Level 2 Member', 'event_espresso'),
+                'access_s2member_level3' => __('Level 3 Member', 'event_espresso'),
+                'access_s2member_level4' => __('Level 4 Member', 'event_espresso'),
             ];
         }
 

--- a/domain/entities/routing/WpUserData.php
+++ b/domain/entities/routing/WpUserData.php
@@ -140,10 +140,7 @@ class WpUserData extends JsonDataNode
                     )
                     : null;
                 if ($extra_meta instanceof EE_Extra_Meta) {
-                    $capabilityRequired                                                      = $extra_meta->value();
-                    $event_editor_gql_data['tickets']['nodes'][ $key ]['capabilityRequired'] = $capabilityRequired;
-                    $ticket_meta_data[ $ticket_node['id'] ]                                  =
-                        ['capabilityRequired' => $capabilityRequired];
+                    $ticket_meta_data[ $ticket_node['id'] ] = ['capabilityRequired' => $extra_meta->value()];
                 }
             }
             $this->setTicketMetaData($ticket_meta_data);

--- a/eea-wpuser-integration.php
+++ b/eea-wpuser-integration.php
@@ -44,9 +44,12 @@ define('EE_WPUSERS_PLUGIN_FILE', __FILE__);
 
 function load_ee_core_wpusers()
 {
-    if (class_exists('EE_Addon')
+    static $loaded = false;
+    if (! $loaded
+        && class_exists('EE_Addon')
         && class_exists('EventEspresso\core\domain\DomainBase')
     ) {
+        $loaded = true;
         define('EE_WPUSERS_PATH', plugin_dir_path(__FILE__));
         define('EE_WPUSERS_URL', plugin_dir_url(__FILE__));
         define('EE_WPUSERS_TEMPLATE_PATH', EE_WPUSERS_PATH . 'templates/');


### PR DESCRIPTION
plz see: #28

This PR:

- adds new `WpUserData` `JsonDataNode` class that:

	- hooks into main `EventEditor` `JsonDataNode` and retrieves ticket meta for all ticket nodes

	- adds ticket capability options for both basic use AND s2Member if it is active

- loads the above data node on EDTR routes

- adds some PHP 7 type safety

PLZ NOTE:

In case it was easier to deal with in the EDTR Apollo code, I've also added the ticket "capabilityRequired" field directly to each ticket node. It doesn't appear to cause problems with the editor but I don't know for sure that it won't. If it's a problem it can easily be removed. This data is also under the "ticketsMeta" object as discussed in #28.

I've also changed the schema for the "capabilityOptions" portion of the WP User DOM data object to be a much more straightforward set of key value pairings. ex:

```
{
	Standard: {
		none: "none",
		read: "Read Capabilities"
	},
	s2Member: {
		access_s2member_level0: "Level 0 Member",
		access_s2member_level1: "Level 1 Member",
		access_s2member_level2: "Level 2 Member",
		access_s2member_level3: "Level 3 Member",
		access_s2member_level4: "Level 4 Member",
	},
}
```

although the `s2Member` section is only added IF that plugin is actually active on the site. This structure makes the data cleaner to transmit and use for any other purposes but you won't be able to use it directly for a select input's options without a little extra work. IMHO this is also safer long term as any changes to how our select inputs work will ONLY require a change to the logic that converts this data into options.