### PR TITLE
Fix Routing

### DIFF
--- a/EE_WPUsers.class.php
+++ b/EE_WPUsers.class.php
@@ -74,7 +74,7 @@ class EE_WPUsers extends EE_Addon
     {
         $this->register_dependencies();
         add_action(
-            'AHEE__EventEspresso_core_services_routing_Router__coreLoadedAndReady',
+            'AHEE__EventEspresso_core_services_routing_Router__brewEspresso',
             [$this, 'handleWpUserRoutes'],
             10,
             3


### PR DESCRIPTION
this PR simply hooks into the core routing process a little earlier so that the WP User GQL route can then hook into the core GQL initialization on time.

closes #32 