### PR TITLE
Always add redirect_to arg to the WP user registration URL

### DIFF
--- a/EED_WP_Users_SPCO.module.php
+++ b/EED_WP_Users_SPCO.module.php
@@ -611,17 +611,20 @@ class EED_WP_Users_SPCO extends EED_Module
                    . esc_html__('Login', 'event_espresso') . '</button>'
                    . '</a>';
         if (get_option('users_can_register')) {
-            $registration_url = ! EE_Registry::instance()->CFG->addons->user_integration->registration_page
-                ? add_query_arg(
+            $registration_base_url = EE_Registry::instance()->CFG->addons->user_integration->registration_page
+                ? EE_Registry::instance()->CFG->addons->user_integration->registration_page
+                : wp_registration_url();
+            $registration_url = esc_url(
+                add_query_arg(
                     [
                         'ee_do_auto_login' => 1,
                         'ee_load_on_login' => 1,
-                        'redirect_to'      => $redirect_to_url_after_login->getFullUrl(),
+                        'redirect_to' => $redirect_to_url_after_login->getFullUrl(),
                     ],
-                    wp_registration_url()
+                    $registration_base_url
                 )
-                : EE_Registry::instance()->CFG->addons->user_integration->registration_page;
-            $buttons          .= '<a class="ee-wpuser-register-link float-right" href="'
+            );
+            $buttons .= '<a class="ee-wpuser-register-link float-right" href="'
                                  . $registration_url
                                  . '">'
                                  . '<button type="button" class="button button-primary">'

--- a/EE_SPCO_Reg_Step_WP_User_Login.class.php
+++ b/EE_SPCO_Reg_Step_WP_User_Login.class.php
@@ -40,18 +40,19 @@ class EE_SPCO_Reg_Step_WP_User_Login extends EE_SPCO_Reg_Step
      */
     public function this_step_initialized(EE_SPCO_Reg_Step_WP_User_Login $spco_step)
     {
-        $registration_url = ! EE_Registry::instance()->CFG->addons->user_integration->registration_page
-            ? esc_url(
-                add_query_arg(
-                    array(
-                        'ee_do_auto_login' => 1,
-                        'ee_load_on_login' => 1,
-                        'redirect_to' => $this->checkout->next_step->reg_step_url(),
-                    ),
-                    wp_registration_url()
-                )
+        $registration_base_url = EE_Registry::instance()->CFG->addons->user_integration->registration_page
+            ? EE_Registry::instance()->CFG->addons->user_integration->registration_page
+            : wp_registration_url();
+        $registration_url = esc_url(
+            add_query_arg(
+                array(
+                    'ee_do_auto_login' => 1,
+                    'ee_load_on_login' => 1,
+                    'redirect_to' => $this->checkout->next_step->reg_step_url(),
+                ),
+                $registration_base_url
             )
-            : EE_Registry::instance()->CFG->addons->user_integration->registration_page;
+        );
         $instructions = get_option('users_can_register')
             ? sprintf(__('The event you have selected requires logging in before you can register. You can %sregister for an account here%s if you don\'t have a login.', 'event_espresso'), '<a href="' . $registration_url . '">', '</a>')
             : __('The event you have selected requires logging in before you can register.', 'event_espresso');


### PR DESCRIPTION
Currently, if you set a custom registration URL in the WP user settings, that URL is used as is which means you lose the redirect back to your EE checkout after registration without custom code.

Not all plugins support/use the `redirect_to` arg on the URL within the registration but many do, so we might as well use it.

This change uses either the URL set in the setting or the wp_registration_url() value for the URL then always adds the `ee_do_auto_login`, `ee_load_on_login`, and  `redirect_to` to those values.

## Problem this Pull Request solves
Redirects back to the checkout page after registration when a custom Registration Page URL is in use.

## How has this been tested
(Without a custom Registration Form set)
Set the event to require registration and then try to register on the front end.

Follow the EE links to confirm you are directed to the registration form and then when registered you are redirected back to the EE checkout.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
