### PR TITLE
Reduce Required Core Version to 4.10.0

### DIFF
--- a/eea-wpuser-integration.php
+++ b/eea-wpuser-integration.php
@@ -7,7 +7,7 @@ if (! defined('ABSPATH')) {
 /*
   Plugin Name:  Event Espresso - WP Users (EE4.6+)
   Plugin URI:  http://www.eventespresso.com
-  Description: This adds the WP users integration.
+  Description: This adds the WP Users integration.
   Version: 2.1.0.rc.003
   Author: Event Espresso
   Author URI: http://www.eventespresso.com
@@ -38,10 +38,14 @@ if (! defined('ABSPATH')) {
  *
  */
 define('EE_WPUSERS_VERSION', '2.1.0.rc.003');
-define('EE_WPUSERS_MIN_CORE_VERSION_REQUIRED', '4.11.0.rc.001');
+define('EE_WPUSERS_MIN_CORE_VERSION_REQUIRED', '4.10.0.p');
 define('EE_WPUSERS_PLUGIN_FILE', __FILE__);
 
 
+/**
+ * @throws EE_Error
+ * @throws ReflectionException
+ */
 function load_ee_core_wpusers()
 {
     static $loaded = false;


### PR DESCRIPTION
This PR does exactly what the title says.

### **PLEASE NOTE**
this branch will not deactivate or prevent the WP User add-on from running with newer versions of EE core, but as is, it will throw errors when used with the EE core `dev` branch. Things will work, but there are errors occurring in the background which could easily interfere with things (i hadn't tested things fully at all).

That said, I rebased the WP User `dev` branch onto this one (checkout `rebased-dev`) and that branch WILL work with both EE core `master` branch (after `make-wp-users-work` is merged) as well as EE core `dev` branch.

So if you want to release a slightly early version of this add-on, then you may want to use that branch instead of this one as it will be more compatible AND means that you don't have to perform an additional release for it to work with EDTR.