### PR TITLE
Swap Icons and Update Request Usage

### DIFF
--- a/EE_WPUsers.class.php
+++ b/EE_WPUsers.class.php
@@ -15,7 +15,7 @@ class EE_WPUsers extends EE_Addon
     /**
      * Set up
      *
-     * @throws EE_Error|ReflectionException
+     * @throws EE_Error
      */
     public static function register_addon()
     {
@@ -94,7 +94,7 @@ class EE_WPUsers extends EE_Addon
             'EventEspresso\WpUser\domain\entities\shortcodes\EspressoMyEvents',
             [
                 'EventEspresso\core\services\cache\PostRelatedCacheManager' => EE_Dependency_Map::load_from_cache,
-                'EE_Request'                                                => EE_Dependency_Map::load_from_cache,
+                'EventEspresso\core\services\request\Request'               => EE_Dependency_Map::load_from_cache,
                 'EEM_Event'                                                 => EE_Dependency_Map::load_from_cache,
                 'EEM_Registration'                                          => EE_Dependency_Map::load_from_cache,
             ]

--- a/templates/content-espresso_my_events-event_section_tickets.template.php
+++ b/templates/content-espresso_my_events-event_section_tickets.template.php
@@ -28,7 +28,7 @@ $ticket = $registration->ticket();
             ? '<a aria-label="' . $link_to_edit_registration_text
               . '" title="' . $link_to_edit_registration_text
               . '" href="' . $registration->edit_attendee_information_url() . '">'
-              . '<span class="ee-icon ee-icon-user-edit ee-icon-size-16"></span></a>'
+              . '<span class="dashicons dashicons-groups ee-icon-size-16"></span></a>'
             : '';
         // resend confirmation email.
         $resend_registration_link = add_query_arg(

--- a/templates/content-espresso_my_events-simple_list_table.template.php
+++ b/templates/content-espresso_my_events-simple_list_table.template.php
@@ -42,7 +42,7 @@
             ? '<a aria-label="' . $link_to_edit_registration_text
               . '" title="' . $link_to_edit_registration_text
               . '" href="' . $registration->edit_attendee_information_url() . '">'
-            . '<span class="ee-icon ee-icon-user-edit ee-icon-size-16"></span></a>'
+            . '<span class="dashicons dashicons-groups ee-icon-size-16"></span></a>'
             : '';
         // resend confirmation email.
         $resend_registration_link = add_query_arg(

--- a/templates/status-legend-espresso_my_events.template.php
+++ b/templates/status-legend-espresso_my_events.template.php
@@ -69,7 +69,7 @@ if ($template_slug == 'event_section') {
 
 // add action icons
 $items['edit_registration']   = array(
-    'class' => 'ee-icon ee-icon-user-edit',
+    'class' => 'dashicons dashicons-groups',
     'desc'  => esc_html__('Edit the registration details.', 'event_espresso'),
 );
 $items['resend_notification'] = array(


### PR DESCRIPTION
This PR:

- swaps out some of the old EE icons for WP core dashicons
- updates some uses of the request object to use the newer version