### PR TITLE
Stop processing if one of the registrations matches a user account and requires login

### DIFF
--- a/EED_WP_Users_SPCO.module.php
+++ b/EED_WP_Users_SPCO.module.php
@@ -503,10 +503,6 @@ class EED_WP_Users_SPCO extends EED_Module
             if (! $registration instanceof EE_Registration) {
                 return $stop_processing;
             }
-            // if stop processing has been set to true, break out of the foreach
-            if ($stop_processing) {
-                break;
-            }
             $reg_url_link = $registration->reg_url_link();
             if (isset($valid_data[ $reg_url_link ]) && is_array($valid_data[ $reg_url_link ])) {
                 foreach ($valid_data[ $reg_url_link ] as $form_inputs) {
@@ -535,6 +531,7 @@ class EED_WP_Users_SPCO extends EED_Module
                             );
                             $stop_processing     = true;
                             $field_input_error[] = 'ee_reg_qstn-' . $registration->ID() . '-email';
+                            break 2;
                         }
                     }
                 }

--- a/EED_WP_Users_SPCO.module.php
+++ b/EED_WP_Users_SPCO.module.php
@@ -503,6 +503,10 @@ class EED_WP_Users_SPCO extends EED_Module
             if (! $registration instanceof EE_Registration) {
                 return $stop_processing;
             }
+            // if stop processing has been set to true, break out of the foreach
+            if ($stop_processing) {
+                break;
+            }
             $reg_url_link = $registration->reg_url_link();
             if (isset($valid_data[ $reg_url_link ]) && is_array($valid_data[ $reg_url_link ])) {
                 foreach ($valid_data[ $reg_url_link ] as $form_inputs) {


### PR DESCRIPTION
To reproduce this, require the personal information question group for additional registrants on an event.

Select at least 2 tickets.

For the primary registrant, use registration details (email) which match a user account (the admin account for example)

For the additional registrant, use any details as long as they DO NOT match a user account on the site.

With master, an empty notice will be shown in place of the log notice... because the first registration matched a user account which 'triggered' the notice, then the second registration is processed and wipes out the notice again.

This change breaks out of registration processing when a user email match is found so that the notice is shown for that specific registration.
